### PR TITLE
Python 3.5 Support plus testing refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,7 @@
-# Config file for automatic testing at travis-ci.org
-
+sudo: false
 language: python
+python: '3.5'
 
-python:
-  - "3.4"
-  - "3.3"
-  - "2.7"
-  - "2.6"
-  - "pypy"
+install: pip install tox
 
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -r requirements.txt
-
-# command to run tests, e.g. python setup.py test
-script: nosetests
+script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, pypy
+envlist = py26, py27, py33, py34, py35, pypy, pypy3
 
 [testenv]
 commands = nosetests {posargs}


### PR DESCRIPTION
Travis launches `tox` rather than multiple environments, to verify packaging and reduce code repetition.
