### PR TITLE
Fix #20 - Output random seed when not resetting the seed at the start of tests

### DIFF
--- a/nose_randomly/plugin.py
+++ b/nose_randomly/plugin.py
@@ -76,12 +76,10 @@ class RandomlyPlugin(Plugin):
             return
 
         self.output_stream = stream
-
-        if self.options.reset_seed:
-            print(
-                "Using --randomly-seed={seed}".format(seed=self.options.seed),
-                file=self.output_stream
-            )
+        print(
+            "Using --randomly-seed={seed}".format(seed=self.options.seed),
+            file=self.output_stream
+        )
 
     def startContext(self, context):
         self.reset_random_seed()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -189,13 +189,14 @@ class DontRandomSeedTest(RandomlyPluginTester, TestCase):
     """
     Check that the random seed is being set.
     """
-    args = ['-v', '--randomly-dont-reset-seed']
+    args = ['-v', '--randomly-seed=1', '--randomly-dont-reset-seed']
     fixture_suite = 'random_seed_not_100.py'
 
     def runTest(self):
         # Just runs the test - the remaining logic is in the file itself,
         # checking that random.random() does not look like the seed is 100
         self.check_output_like([
+            'Using --randomly-seed=1',
             'test_not_reseeded_to_100 (random_seed_not_100.Tests) ... ok'
         ])
 


### PR DESCRIPTION
Prints the `reset_seed` if the plugin is enabled. Fixes #20.
